### PR TITLE
bug: #9 - "CSV" texts dont match

### DIFF
--- a/app/client/src/main.ts
+++ b/app/client/src/main.ts
@@ -239,7 +239,7 @@ function displayResults(response: QueryResponse, query: string) {
     // Create export button
     const exportButton = document.createElement('button');
     exportButton.className = 'export-button secondary-button';
-    exportButton.innerHTML = `${getDownloadIcon()} Export`;
+    exportButton.innerHTML = getDownloadIcon();
     exportButton.title = 'Export results as CSV';
     exportButton.onclick = async () => {
       try {

--- a/specs/patch/patch-adw-Issue-fix-csv-button-text.md
+++ b/specs/patch/patch-adw-Issue-fix-csv-button-text.md
@@ -1,0 +1,35 @@
+# Patch: Fix CSV export button text in query results section
+
+## Metadata
+adw_id: `Issue`
+review_change_request: `Issue #9: "CSV" texts dont match - Under available tables section the csv export button has the correct text "in CSV". Update the query result section csv export button text should match this.`
+
+## Issue Summary
+**Original Spec:**
+**Issue:** The query results section export button displays "📊 CSV Export" (getDownloadIcon() + " Export"), while the available tables section export button correctly displays just "📊 CSV" (getDownloadIcon() only). The texts don't match.
+**Solution:** Remove the " Export" suffix from the query results export button so it matches the available tables section button text.
+
+## Files to Modify
+- `app/client/src/main.ts`
+
+## Implementation Steps
+
+### Step 1: Update query results export button text
+- In `app/client/src/main.ts` at line 242, change:
+  ```ts
+  exportButton.innerHTML = `${getDownloadIcon()} Export`;
+  ```
+  to:
+  ```ts
+  exportButton.innerHTML = getDownloadIcon();
+  ```
+
+## Validation
+1. Start the app and verify the query results export button now shows "📊 CSV" instead of "📊 CSV Export"
+2. Verify the available tables export button still shows "📊 CSV"
+3. Verify both buttons function correctly (export works)
+
+## Patch Scope
+**Lines of code to change:** 1
+**Risk level:** low
+**Testing required:** Visual check that both CSV export buttons display identical text


### PR DESCRIPTION
## Summary

This PR fixes the inconsistency in CSV export button text between the available tables section and query results section. 

**Issue:** The query results export button was displaying "📊 CSV Export" while the available tables export button correctly displays "📊 CSV".

**Solution:** Updated the query results export button to display matching text by removing the " Export" suffix.

Closes #9

### ADW Tracking
- ADW ID: 78c9c458

### Changes Made
- ✅ Updated query results export button text in `app/client/src/main.ts`
- ✅ Button now displays "📊 CSV" to match available tables export button
- ✅ Functionality remains unchanged

### Testing
- Visual verification that both export buttons display identical text
- Both buttons continue to function correctly